### PR TITLE
Remove extra comma from meta-netkan

### DIFF
--- a/CKAN/MarkIVSpaceplaneSystem.netkan
+++ b/CKAN/MarkIVSpaceplaneSystem.netkan
@@ -19,7 +19,7 @@
     ],
     "suggests": [
         { "name" : "CommunityTechTree" },
-        { "name" : "NearFutureAeronautics" },
+        { "name" : "NearFutureAeronautics" }
     ],
     "supports": [
         { "name" : "ConnectedLivingSpace" },


### PR DESCRIPTION
CKAN's download counter has been emitting a mystery error for a couple of nights:

![image](https://user-images.githubusercontent.com/1559108/103320708-17835000-49fc-11eb-8156-35857db625b9.png)

Luckily the actual indexing of the mod apparently is fine (I guess C# is more forgiving than Python).
This seems to be due to a minor syntax erorr in the metanetkan, there's an extra comma at the end of a list.
Now it's gone.

Tagging @ChrisAdderley to ensure GitHub sends a notification.